### PR TITLE
pkgs/test/top-level: add tests for package set composability

### DIFF
--- a/pkgs/test/top-level/default.nix
+++ b/pkgs/test/top-level/default.nix
@@ -105,10 +105,8 @@ lib.recurseIntoAttrs {
       assert isIdempotent "pkgsi686Linux";
       assert isIdempotent "pkgsx86_64Darwin";
 
-      # TODO: fails
-      # assert isNoop [ "pkgsStatic" ] "pkgsMusl";
-      # TODO: fails because of ppc64-musl
-      # assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsMusl") allMuslExamples;
+      assert isNoop [ "pkgsStatic" ] "pkgsMusl";
+      assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsMusl") allMuslExamples;
       assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsLLVM") allLLVMExamples;
 
       assert isComposable "pkgsExtraHardening";
@@ -116,23 +114,23 @@ lib.recurseIntoAttrs {
       assert isComposable "pkgsArocc";
       # TODO: unexpected argument 'bintools' - uncomment once https://github.com/NixOS/nixpkgs/pull/331011 is done
       # assert isComposable "pkgsZig";
-      # TODO: attribute 'abi' missing
-      # assert isComposable "pkgsMusl";
-      # TODO: fails
-      # assert isComposable "pkgsStatic";
-      # assert isComposable "pkgsi686Linux";
+      assert isComposable "pkgsMusl";
+      assert isComposable "pkgsStatic";
+      assert isComposable "pkgsi686Linux";
 
       # Special cases regarding buildPlatform vs hostPlatform
-      # TODO: fails
-      # assert discardEvaluationErrors (pkgsCross.gnu64.pkgsMusl.stdenv.hostPlatform.isMusl);
-      # assert discardEvaluationErrors (pkgsCross.gnu64.pkgsi686Linux.stdenv.hostPlatform.isx86_32);
-      # assert discardEvaluationErrors (pkgsCross.mingwW64.pkgsLinux.stdenv.hostPlatform.isLinux);
-      # assert discardEvaluationErrors (pkgsCross.aarch64-darwin.pkgsx86_64Darwin.stdenv.hostPlatform.isx86_64);
+      assert discardEvaluationErrors (pkgsCross.gnu64.pkgsMusl.stdenv.hostPlatform.isMusl);
+      assert discardEvaluationErrors (pkgsCross.gnu64.pkgsi686Linux.stdenv.hostPlatform.isx86_32);
+      assert discardEvaluationErrors (pkgsCross.mingwW64.pkgsLinux.stdenv.hostPlatform.isLinux);
+      assert discardEvaluationErrors (pkgsCross.aarch64-darwin.pkgsx86_64Darwin.stdenv.hostPlatform.isx86_64);
 
       # pkgsCross should keep upper cross settings
-      # TODO: fails
-      # assert discardEvaluationErrors (with pkgsStatic.pkgsCross.gnu64.stdenv.hostPlatform; isGnu && isStatic);
-      # assert discardEvaluationErrors (with pkgsLLVM.pkgsCross.musl64.stdenv.hostPlatform; isMusl && useLLVM);
+      assert discardEvaluationErrors (with pkgsStatic.pkgsCross.gnu64.stdenv.hostPlatform; isGnu && isStatic);
+      assert discardEvaluationErrors (with pkgsLLVM.pkgsCross.musl64.stdenv.hostPlatform; isMusl && useLLVM);
+
+      # pkgsCross should keep upper cross settings
+      assert discardEvaluationErrors (with pkgsStatic.pkgsCross.gnu64.stdenv.hostPlatform; isGnu && isStatic);
+      assert discardEvaluationErrors (with pkgsLLVM.pkgsCross.musl64.stdenv.hostPlatform; isMusl && useLLVM);
 
       emptyFile;
 }

--- a/pkgs/test/top-level/default.nix
+++ b/pkgs/test/top-level/default.nix
@@ -105,8 +105,10 @@ lib.recurseIntoAttrs {
       assert isIdempotent "pkgsi686Linux";
       assert isIdempotent "pkgsx86_64Darwin";
 
-      assert isNoop [ "pkgsStatic" ] "pkgsMusl";
-      assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsMusl") allMuslExamples;
+      # TODO: fails
+      # assert isNoop [ "pkgsStatic" ] "pkgsMusl";
+      # TODO: fails because of ppc64-musl
+      # assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsMusl") allMuslExamples;
       assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsLLVM") allLLVMExamples;
 
       assert isComposable "pkgsExtraHardening";
@@ -114,23 +116,23 @@ lib.recurseIntoAttrs {
       assert isComposable "pkgsArocc";
       # TODO: unexpected argument 'bintools' - uncomment once https://github.com/NixOS/nixpkgs/pull/331011 is done
       # assert isComposable "pkgsZig";
-      assert isComposable "pkgsMusl";
-      assert isComposable "pkgsStatic";
-      assert isComposable "pkgsi686Linux";
+      # TODO: attribute 'abi' missing
+      # assert isComposable "pkgsMusl";
+      # TODO: fails
+      # assert isComposable "pkgsStatic";
+      # assert isComposable "pkgsi686Linux";
 
       # Special cases regarding buildPlatform vs hostPlatform
-      assert discardEvaluationErrors (pkgsCross.gnu64.pkgsMusl.stdenv.hostPlatform.isMusl);
-      assert discardEvaluationErrors (pkgsCross.gnu64.pkgsi686Linux.stdenv.hostPlatform.isx86_32);
-      assert discardEvaluationErrors (pkgsCross.mingwW64.pkgsLinux.stdenv.hostPlatform.isLinux);
-      assert discardEvaluationErrors (pkgsCross.aarch64-darwin.pkgsx86_64Darwin.stdenv.hostPlatform.isx86_64);
+      # TODO: fails
+      # assert discardEvaluationErrors (pkgsCross.gnu64.pkgsMusl.stdenv.hostPlatform.isMusl);
+      # assert discardEvaluationErrors (pkgsCross.gnu64.pkgsi686Linux.stdenv.hostPlatform.isx86_32);
+      # assert discardEvaluationErrors (pkgsCross.mingwW64.pkgsLinux.stdenv.hostPlatform.isLinux);
+      # assert discardEvaluationErrors (pkgsCross.aarch64-darwin.pkgsx86_64Darwin.stdenv.hostPlatform.isx86_64);
 
       # pkgsCross should keep upper cross settings
-      assert discardEvaluationErrors (with pkgsStatic.pkgsCross.gnu64.stdenv.hostPlatform; isGnu && isStatic);
-      assert discardEvaluationErrors (with pkgsLLVM.pkgsCross.musl64.stdenv.hostPlatform; isMusl && useLLVM);
-
-      # pkgsCross should keep upper cross settings
-      assert discardEvaluationErrors (with pkgsStatic.pkgsCross.gnu64.stdenv.hostPlatform; isGnu && isStatic);
-      assert discardEvaluationErrors (with pkgsLLVM.pkgsCross.musl64.stdenv.hostPlatform; isMusl && useLLVM);
+      # TODO: fails
+      # assert discardEvaluationErrors (with pkgsStatic.pkgsCross.gnu64.stdenv.hostPlatform; isGnu && isStatic);
+      # assert discardEvaluationErrors (with pkgsLLVM.pkgsCross.musl64.stdenv.hostPlatform; isMusl && useLLVM);
 
       emptyFile;
 }

--- a/pkgs/test/top-level/default.nix
+++ b/pkgs/test/top-level/default.nix
@@ -44,4 +44,95 @@ lib.recurseIntoAttrs {
     assert lib.all (p: p.buildPlatform == p.hostPlatform) pkgsLocal;
     assert lib.all (p: p.buildPlatform != p.hostPlatform) pkgsCross;
     pkgs.emptyFile;
+
+  composePackageSets = with pkgs;
+    let
+      # To silence platform specific evaluation errors
+      discardEvaluationErrors = e:
+        let res = builtins.tryEval e; in
+        res.success == res.value;
+
+      # Basic test for idempotency of the package set, i.e:
+      # Applying the same package set twice should work and
+      # not change anything.
+      isIdempotent = set: discardEvaluationErrors (
+        pkgs.${set}.stdenv == pkgs.${set}.${set}.stdenv
+      );
+
+      # Some package sets should be noops in certain circumstances.
+      # This is very similar to the idempotency test, but not going
+      # via the super' overlay.
+      isNoop = parent: child: discardEvaluationErrors (
+        (lib.getAttrFromPath parent pkgs).stdenv ==
+        (lib.getAttrFromPath parent pkgs).${child}.stdenv
+      );
+
+      allMuslExamples = builtins.attrNames (lib.filterAttrs
+        (_: { config, ... }: lib.hasSuffix "-musl" config)
+        lib.systems.examples);
+
+      allLLVMExamples = builtins.attrNames (lib.filterAttrs
+        (_: { useLLVM ? false, ... }: useLLVM)
+        lib.systems.examples);
+
+      # A package set should only change specific configuration, but needs
+      # to keep all other configuration from previous layers in place.
+      # Each package set has one or more key characteristics for which we
+      # test here. Those should be kept, even when applying the "set" package
+      # set.
+      isComposable = set:
+        discardEvaluationErrors (pkgsCross.mingwW64.${set}.stdenv.hostPlatform.config == "x86_64-w64-mingw32") &&
+        discardEvaluationErrors (pkgsCross.mingwW64.${set}.stdenv.hostPlatform.libc == "msvcrt") &&
+        discardEvaluationErrors (pkgsCross.ppc64-musl.${set}.stdenv.hostPlatform.gcc.abi == "elfv2") &&
+        discardEvaluationErrors (builtins.elem "trivialautovarinit" pkgs.pkgsExtraHardening.${set}.stdenv.cc.defaultHardeningFlags) &&
+        discardEvaluationErrors (pkgs.pkgsLLVM.${set}.stdenv.hostPlatform.useLLVM) &&
+        discardEvaluationErrors (pkgs.pkgsArocc.${set}.stdenv.hostPlatform.useArocc) &&
+        discardEvaluationErrors (pkgs.pkgsZig.${set}.stdenv.hostPlatform.useZig) &&
+        discardEvaluationErrors (pkgs.pkgsLinux.${set}.stdenv.buildPlatform.isLinux) &&
+        discardEvaluationErrors (pkgs.pkgsMusl.${set}.stdenv.hostPlatform.isMusl) &&
+        discardEvaluationErrors (pkgs.pkgsStatic.${set}.stdenv.hostPlatform.isStatic) &&
+        discardEvaluationErrors (pkgs.pkgsi686Linux.${set}.stdenv.hostPlatform.isx86_32) &&
+        discardEvaluationErrors (pkgs.pkgsx86_64Darwin.${set}.stdenv.hostPlatform.isx86_64);
+    in
+      # Appends same flags over and over again
+      # assert isIdempotent "pkgsExtraHardening";
+      assert isIdempotent "pkgsLLVM";
+      assert isIdempotent "pkgsArocc";
+      assert isIdempotent "pkgsZig";
+      assert isIdempotent "pkgsLinux";
+      assert isIdempotent "pkgsMusl";
+      assert isIdempotent "pkgsStatic";
+      assert isIdempotent "pkgsi686Linux";
+      assert isIdempotent "pkgsx86_64Darwin";
+
+      # TODO: fails
+      # assert isNoop [ "pkgsStatic" ] "pkgsMusl";
+      # TODO: fails because of ppc64-musl
+      # assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsMusl") allMuslExamples;
+      assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsLLVM") allLLVMExamples;
+
+      assert isComposable "pkgsExtraHardening";
+      assert isComposable "pkgsLLVM";
+      assert isComposable "pkgsArocc";
+      # TODO: unexpected argument 'bintools' - uncomment once https://github.com/NixOS/nixpkgs/pull/331011 is done
+      # assert isComposable "pkgsZig";
+      # TODO: attribute 'abi' missing
+      # assert isComposable "pkgsMusl";
+      # TODO: fails
+      # assert isComposable "pkgsStatic";
+      # assert isComposable "pkgsi686Linux";
+
+      # Special cases regarding buildPlatform vs hostPlatform
+      # TODO: fails
+      # assert discardEvaluationErrors (pkgsCross.gnu64.pkgsMusl.stdenv.hostPlatform.isMusl);
+      # assert discardEvaluationErrors (pkgsCross.gnu64.pkgsi686Linux.stdenv.hostPlatform.isx86_32);
+      # assert discardEvaluationErrors (pkgsCross.mingwW64.pkgsLinux.stdenv.hostPlatform.isLinux);
+      # assert discardEvaluationErrors (pkgsCross.aarch64-darwin.pkgsx86_64Darwin.stdenv.hostPlatform.isx86_64);
+
+      # pkgsCross should keep upper cross settings
+      # TODO: fails
+      # assert discardEvaluationErrors (with pkgsStatic.pkgsCross.gnu64.stdenv.hostPlatform; isGnu && isStatic);
+      # assert discardEvaluationErrors (with pkgsLLVM.pkgsCross.musl64.stdenv.hostPlatform; isMusl && useLLVM);
+
+      emptyFile;
 }

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -121,7 +121,7 @@ in let
   # via `evalModules` is not idempotent. In other words, if you add `config` to
   # `newArgs`, expect strange very hard to debug errors! (Yes, I'm speaking from
   # experience here.)
-  nixpkgsFun = newArgs: import ./. (args // newArgs);
+  nixpkgsFun = f0: import ./. (args // f0 args);
 
   # Partially apply some arguments for building bootstraping stage pkgs
   # sets. Only apply arguments which no stdenv would want to override.

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -101,22 +101,18 @@ in let
   config = lib.showWarnings configEval.config.warnings configEval.config;
 
   # A few packages make a new package set to draw their dependencies from.
-  # (Currently to get a cross tool chain, or forced-i686 package.) Rather than
-  # give `all-packages.nix` all the arguments to this function, even ones that
-  # don't concern it, we give it this function to "re-call" nixpkgs, inheriting
-  # whatever arguments it doesn't explicitly provide. This way,
-  # `all-packages.nix` doesn't know more than it needs too.
+  # Rather than give `all-packages.nix` all the arguments to this function,
+  # even ones that don't concern it, we give it this function to "re-call"
+  # nixpkgs, inheriting whatever arguments it doesn't explicitly provide. This
+  # way, `all-packages.nix` doesn't know more than it needs to.
   #
   # It's OK that `args` doesn't include default arguments from this file:
   # they'll be deterministically inferred. In fact we must *not* include them,
   # because it's important that if some parameter which affects the default is
   # substituted with a different argument, the default is re-inferred.
   #
-  # To put this in concrete terms, this function is basically just used today to
-  # use package for a different platform for the current platform (namely cross
-  # compiling toolchains and 32-bit packages on x86_64). In both those cases we
-  # want the provided non-native `localSystem` argument to affect the stdenv
-  # chosen.
+  # To put this in concrete terms, we want the provided non-native `localSystem`
+  # and `crossSystem` arguments to affect the stdenv chosen.
   #
   # NB!!! This thing gets its `config` argument from `args`, i.e. it's actually
   # `config0`. It is important to keep it to `config0` format (as opposed to the

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -176,12 +176,7 @@ let
       ((config.packageOverrides or (super: {})) super);
 
   # Convenience attributes for instantitating package sets. Each of
-  # these will instantiate a new version of allPackages. Currently the
-  # following package sets are provided:
-  #
-  # - pkgsCross.<system> where system is a member of lib.systems.examples
-  # - pkgsMusl
-  # - pkgsi686Linux
+  # these will instantiate a new version of allPackages.
   otherPackageSets = self: super: {
     # This maps each entry in lib.systems.examples to its own package
     # set. Each of these will contain all packages cross compiled for

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -177,7 +177,15 @@ let
 
   # Convenience attributes for instantitating package sets. Each of
   # these will instantiate a new version of allPackages.
-  otherPackageSets = self: super: {
+  otherPackageSets = let
+    mkPkgs = name: nixpkgsArgs: nixpkgsFun (nixpkgsArgs // {
+      overlays = [
+        (self': super': {
+          "${name}" = super';
+        })
+      ] ++ nixpkgsArgs.overlays or [] ++ overlays;
+    });
+  in self: super: {
     # This maps each entry in lib.systems.examples to its own package
     # set. Each of these will contain all packages cross compiled for
     # that target system. For instance, pkgsCross.raspberryPi.hello,
@@ -187,12 +195,7 @@ let
                               nixpkgsFun { inherit crossSystem; })
                               lib.systems.examples;
 
-    pkgsLLVM = nixpkgsFun {
-      overlays = [
-        (self': super': {
-          pkgsLLVM = super';
-        })
-      ] ++ overlays;
+    pkgsLLVM = mkPkgs "pkgsLLVM" {
       # Bootstrap a cross stdenv using the LLVM toolchain.
       # This is currently not possible when compiling natively,
       # so we don't need to check hostPlatform != buildPlatform.
@@ -202,12 +205,7 @@ let
       };
     };
 
-    pkgsArocc = nixpkgsFun {
-      overlays = [
-        (self': super': {
-          pkgsArocc = super';
-        })
-      ] ++ overlays;
+    pkgsArocc = mkPkgs "pkgsArocc" {
       # Bootstrap a cross stdenv using the Aro C compiler.
       # This is currently not possible when compiling natively,
       # so we don't need to check hostPlatform != buildPlatform.
@@ -217,12 +215,7 @@ let
       };
     };
 
-    pkgsZig = nixpkgsFun {
-      overlays = [
-        (self': super': {
-          pkgsZig = super';
-        })
-      ] ++ overlays;
+    pkgsZig = mkPkgs "pkgsZig" {
       # Bootstrap a cross stdenv using the Zig toolchain.
       # This is currently not possible when compiling natively,
       # so we don't need to check hostPlatform != buildPlatform.
@@ -235,10 +228,7 @@ let
     # All packages built with the Musl libc. This will override the
     # default GNU libc on Linux systems. Non-Linux systems are not
     # supported. 32-bit is also not supported.
-    pkgsMusl = if stdenv.hostPlatform.isLinux && stdenv.buildPlatform.is64bit then nixpkgsFun {
-      overlays = [ (self': super': {
-        pkgsMusl = super';
-      })] ++ overlays;
+    pkgsMusl = if stdenv.hostPlatform.isLinux && stdenv.buildPlatform.is64bit then mkPkgs "pkgsMusl" {
       ${if stdenv.hostPlatform == stdenv.buildPlatform
         then "localSystem" else "crossSystem"} = {
         config = lib.systems.parse.tripleFromSystem (makeMuslParsedPlatform stdenv.hostPlatform.parsed);
@@ -247,10 +237,7 @@ let
 
     # All packages built for i686 Linux.
     # Used by wine, firefox with debugging version of Flash, ...
-    pkgsi686Linux = if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86 then nixpkgsFun {
-      overlays = [ (self': super': {
-        pkgsi686Linux = super';
-      })] ++ overlays;
+    pkgsi686Linux = if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86 then mkPkgs "pkgsi686Linux" {
       ${if stdenv.hostPlatform == stdenv.buildPlatform
         then "localSystem" else "crossSystem"} = {
         config = lib.systems.parse.tripleFromSystem (stdenv.hostPlatform.parsed // {
@@ -260,10 +247,7 @@ let
     } else throw "i686 Linux package set can only be used with the x86 family.";
 
     # x86_64-darwin packages for aarch64-darwin users to use with Rosetta for incompatible packages
-    pkgsx86_64Darwin = if stdenv.hostPlatform.isDarwin then nixpkgsFun {
-      overlays = [ (self': super': {
-        pkgsx86_64Darwin = super';
-      })] ++ overlays;
+    pkgsx86_64Darwin = if stdenv.hostPlatform.isDarwin then mkPkgs "pkgsx86_64Darwin" {
       localSystem = {
         config = lib.systems.parse.tripleFromSystem (stdenv.hostPlatform.parsed // {
           cpu = lib.systems.parse.cpuTypes.x86_64;
@@ -273,20 +257,16 @@ let
 
     # If already linux: the same package set unaltered
     # Otherwise, return a natively built linux package set for the current cpu architecture string.
-    # (ABI and other details will be set to the default for the cpu/os pair)
     pkgsLinux =
       if stdenv.hostPlatform.isLinux
       then self
-      else nixpkgsFun {
+      else mkPkgs "pkgsLinux" {
         localSystem = lib.systems.elaborate "${stdenv.hostPlatform.parsed.cpu.name}-linux";
       };
 
     # Fully static packages.
     # Currently uses Musl on Linux (couldn’t get static glibc to work).
-    pkgsStatic = nixpkgsFun ({
-      overlays = [ (self': super': {
-        pkgsStatic = super';
-      })] ++ overlays;
+    pkgsStatic = mkPkgs "pkgsStatic" {
       crossSystem = {
         isStatic = true;
         config = lib.systems.parse.tripleFromSystem (
@@ -297,12 +277,11 @@ let
         gcc = lib.optionalAttrs (stdenv.hostPlatform.system == "powerpc64-linux") { abi = "elfv2"; } //
           stdenv.hostPlatform.gcc or {};
       };
-    });
+    };
 
-    pkgsExtraHardening = nixpkgsFun {
+    pkgsExtraHardening = mkPkgs "pkgsExtraHardening" {
       overlays = [
         (self': super': {
-          pkgsExtraHardening = super';
           stdenv = super'.withDefaultHardeningFlags (
             super'.stdenv.cc.defaultHardeningFlags ++ [
               "shadowstack"
@@ -321,7 +300,7 @@ let
           pcre-cpp = super'.pcre-cpp.override { enableJit = false; };
           pcre16 = super'.pcre16.override { enableJit = false; };
         })
-      ] ++ overlays;
+      ];
     };
 
     # Extend the package set with zero or more overlays. This preserves

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -178,12 +178,12 @@ let
   # Convenience attributes for instantitating package sets. Each of
   # these will instantiate a new version of allPackages.
   otherPackageSets = let
-    mkPkgs = name: nixpkgsArgs: nixpkgsFun (nixpkgsArgs // {
+    mkPkgs = name: fn: nixpkgsFun (prevArgs: let nixpkgsArgs = fn prevArgs; in nixpkgsArgs // {
       overlays = [
         (self': super': {
           "${name}" = super';
         })
-      ] ++ nixpkgsArgs.overlays or [] ++ overlays;
+      ] ++ nixpkgsArgs.overlays or [] ++ prevArgs.overlays;
     });
   in self: super: {
     # This maps each entry in lib.systems.examples to its own package
@@ -192,94 +192,92 @@ let
     # will refer to the "hello" package built for the ARM6-based
     # Raspberry Pi.
     pkgsCross = lib.mapAttrs (n: crossSystem:
-                              nixpkgsFun { inherit crossSystem; })
+                              nixpkgsFun (prevArgs: { crossSystem = (lib.systems.systemToAttrs (lib.defaultTo { } prevArgs.crossSystem or null)) // crossSystem; }))
                               lib.systems.examples;
 
-    pkgsLLVM = mkPkgs "pkgsLLVM" {
+    pkgsLLVM = mkPkgs "pkgsLLVM" (prevArgs: {
       # Bootstrap a cross stdenv using the LLVM toolchain.
       # This is currently not possible when compiling natively,
-      # so we don't need to check hostPlatform != buildPlatform.
-      crossSystem = stdenv.hostPlatform // {
+      # so we don't need to check whether we are cross already.
+      crossSystem = (lib.systems.systemToAttrs (lib.defaultTo prevArgs.localSystem prevArgs.crossSystem or null)) // {
         useLLVM = true;
         linker = "lld";
       };
-    };
+    });
 
-    pkgsArocc = mkPkgs "pkgsArocc" {
+    pkgsArocc = mkPkgs "pkgsArocc" (prevArgs: {
       # Bootstrap a cross stdenv using the Aro C compiler.
       # This is currently not possible when compiling natively,
-      # so we don't need to check hostPlatform != buildPlatform.
-      crossSystem = stdenv.hostPlatform // {
+      # so we don't need to check whether we are cross already.
+      crossSystem = (lib.systems.systemToAttrs (lib.defaultTo prevArgs.localSystem prevArgs.crossSystem or null)) // {
         useArocc = true;
         linker = "lld";
       };
-    };
+    });
 
-    pkgsZig = mkPkgs "pkgsZig" {
+    pkgsZig = mkPkgs "pkgsZig" (prevArgs: {
       # Bootstrap a cross stdenv using the Zig toolchain.
       # This is currently not possible when compiling natively,
-      # so we don't need to check hostPlatform != buildPlatform.
-      crossSystem = stdenv.hostPlatform // {
+      # so we don't need to check whether we are cross already.
+      crossSystem = (lib.systems.systemToAttrs (lib.defaultTo prevArgs.localSystem prevArgs.crossSystem or null)) // {
         useZig = true;
         linker = "lld";
       };
-    };
+    });
 
     # All packages built with the Musl libc. This will override the
     # default GNU libc on Linux systems. Non-Linux systems are not
     # supported. 32-bit is also not supported.
-    pkgsMusl = if stdenv.hostPlatform.isLinux && stdenv.buildPlatform.is64bit then mkPkgs "pkgsMusl" {
-      ${if stdenv.hostPlatform == stdenv.buildPlatform
-        then "localSystem" else "crossSystem"} = {
+    pkgsMusl = if stdenv.hostPlatform.isLinux && stdenv.buildPlatform.is64bit then mkPkgs "pkgsMusl" (prevArgs: {
+      ${if prevArgs ? crossSystem then "crossSystem" else "localSystem"} = (lib.systems.systemToAttrs (lib.defaultTo prevArgs.localSystem prevArgs.crossSystem or null)) // {
         config = lib.systems.parse.tripleFromSystem (makeMuslParsedPlatform stdenv.hostPlatform.parsed);
       };
-    } else throw "Musl libc only supports 64-bit Linux systems.";
+    }) else throw "Musl libc only supports 64-bit Linux systems.";
 
     # All packages built for i686 Linux.
     # Used by wine, firefox with debugging version of Flash, ...
-    pkgsi686Linux = if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86 then mkPkgs "pkgsi686Linux" {
-      ${if stdenv.hostPlatform == stdenv.buildPlatform
-        then "localSystem" else "crossSystem"} = {
+    pkgsi686Linux = if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86 then mkPkgs "pkgsi686Linux" (prevArgs: {
+      ${if prevArgs ? crossSystem then "crossSystem" else "localSystem"} = (lib.systems.systemToAttrs (lib.defaultTo prevArgs.localSystem prevArgs.crossSystem or null)) // {
         config = lib.systems.parse.tripleFromSystem (stdenv.hostPlatform.parsed // {
           cpu = lib.systems.parse.cpuTypes.i686;
         });
       };
-    } else throw "i686 Linux package set can only be used with the x86 family.";
+    }) else throw "i686 Linux package set can only be used with the x86 family.";
 
     # x86_64-darwin packages for aarch64-darwin users to use with Rosetta for incompatible packages
-    pkgsx86_64Darwin = if stdenv.hostPlatform.isDarwin then mkPkgs "pkgsx86_64Darwin" {
-      localSystem = {
+    pkgsx86_64Darwin = if stdenv.hostPlatform.isDarwin then mkPkgs "pkgsx86_64Darwin" (prevArgs: {
+      ${if prevArgs ? crossSystem then "crossSystem" else "localSystem"} = (lib.systems.systemToAttrs (lib.defaultTo prevArgs.localSystem prevArgs.crossSystem or null)) // {
         config = lib.systems.parse.tripleFromSystem (stdenv.hostPlatform.parsed // {
           cpu = lib.systems.parse.cpuTypes.x86_64;
         });
       };
-    } else throw "x86_64 Darwin package set can only be used on Darwin systems.";
+    }) else throw "x86_64 Darwin package set can only be used on Darwin systems.";
 
     # If already linux: the same package set unaltered
-    # Otherwise, return a natively built linux package set for the current cpu architecture string.
+    # Otherwise, return a linux package set for the current cpu architecture string.
+    # (ABI and other details will be set to the default for the cpu/os pair)
     pkgsLinux =
       if stdenv.hostPlatform.isLinux
       then self
-      else mkPkgs "pkgsLinux" {
-        localSystem = lib.systems.elaborate "${stdenv.hostPlatform.parsed.cpu.name}-linux";
-      };
+      else mkPkgs "pkgsLinux" (prevArgs: {
+        ${if prevArgs ? crossSystem then "crossSystem" else "localSystem"} = (lib.systems.systemToAttrs (lib.defaultTo prevArgs.localSystem prevArgs.crossSystem or null)) // {
+          config = lib.systems.parse.tripleFromSystem (lib.systems.elaborate "${stdenv.hostPlatform.parsed.cpu.name}-linux").parsed;
+        };
+      });
 
     # Fully static packages.
     # Currently uses Musl on Linux (couldn’t get static glibc to work).
-    pkgsStatic = mkPkgs "pkgsStatic" {
-      crossSystem = {
+    pkgsStatic = mkPkgs "pkgsStatic" (prevArgs: {
+      crossSystem = (lib.systems.systemToAttrs (lib.defaultTo prevArgs.localSystem prevArgs.crossSystem or null)) // {
         isStatic = true;
-        config = lib.systems.parse.tripleFromSystem (
-          if stdenv.hostPlatform.isLinux
-          then makeMuslParsedPlatform stdenv.hostPlatform.parsed
-          else stdenv.hostPlatform.parsed
-        );
-        gcc = lib.optionalAttrs (stdenv.hostPlatform.system == "powerpc64-linux") { abi = "elfv2"; } //
-          stdenv.hostPlatform.gcc or {};
+      } // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+        config = lib.systems.parse.tripleFromSystem (makeMuslParsedPlatform stdenv.hostPlatform.parsed);
+      } // lib.optionalAttrs (stdenv.hostPlatform.system == "powerpc64-linux") {
+        gcc = { abi = "elfv2"; } // stdenv.hostPlatform.gcc or {};
       };
-    };
+    });
 
-    pkgsExtraHardening = mkPkgs "pkgsExtraHardening" {
+    pkgsExtraHardening = mkPkgs "pkgsExtraHardening" (_: {
       overlays = [
         (self': super': {
           stdenv = super'.withDefaultHardeningFlags (
@@ -301,7 +299,7 @@ let
           pcre16 = super'.pcre16.override { enableJit = false; };
         })
       ];
-    };
+    });
 
     # Extend the package set with zero or more overlays. This preserves
     # preexisting overlays. Prefer to initialize with the right overlays
@@ -309,7 +307,7 @@ let
     appendOverlays = extraOverlays:
       if extraOverlays == []
       then self
-      else nixpkgsFun { overlays = args.overlays ++ extraOverlays; };
+      else nixpkgsFun (prevArgs: { overlays = prevArgs.overlays ++ extraOverlays; });
 
     # NOTE: each call to extend causes a full nixpkgs rebuild, adding ~130MB
     #       of allocations. DO NOT USE THIS IN NIXPKGS.

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -281,23 +281,6 @@ let
         localSystem = lib.systems.elaborate "${stdenv.hostPlatform.parsed.cpu.name}-linux";
       };
 
-    # Extend the package set with zero or more overlays. This preserves
-    # preexisting overlays. Prefer to initialize with the right overlays
-    # in one go when calling Nixpkgs, for performance and simplicity.
-    appendOverlays = extraOverlays:
-      if extraOverlays == []
-      then self
-      else nixpkgsFun { overlays = args.overlays ++ extraOverlays; };
-
-    # NOTE: each call to extend causes a full nixpkgs rebuild, adding ~130MB
-    #       of allocations. DO NOT USE THIS IN NIXPKGS.
-    #
-    # Extend the package set with a single overlay. This preserves
-    # preexisting overlays. Prefer to initialize with the right overlays
-    # in one go when calling Nixpkgs, for performance and simplicity.
-    # Prefer appendOverlays if used repeatedly.
-    extend = f: self.appendOverlays [f];
-
     # Fully static packages.
     # Currently uses Musl on Linux (couldn’t get static glibc to work).
     pkgsStatic = nixpkgsFun ({
@@ -340,6 +323,23 @@ let
         })
       ] ++ overlays;
     };
+
+    # Extend the package set with zero or more overlays. This preserves
+    # preexisting overlays. Prefer to initialize with the right overlays
+    # in one go when calling Nixpkgs, for performance and simplicity.
+    appendOverlays = extraOverlays:
+      if extraOverlays == []
+      then self
+      else nixpkgsFun { overlays = args.overlays ++ extraOverlays; };
+
+    # NOTE: each call to extend causes a full nixpkgs rebuild, adding ~130MB
+    #       of allocations. DO NOT USE THIS IN NIXPKGS.
+    #
+    # Extend the package set with a single overlay. This preserves
+    # preexisting overlays. Prefer to initialize with the right overlays
+    # in one go when calling Nixpkgs, for performance and simplicity.
+    # Prefer appendOverlays if used repeatedly.
+    extend = f: self.appendOverlays [f];
   };
 
   # The complete chain of package set builders, applied from top to bottom.


### PR DESCRIPTION
This adds some basic tests to compose package sets. The cases that are currently broken
are commented out, they include things like:

- pkgsStatic.pkgsMusl losing the isStatic flag
- pkgsCross.ppc64-musl.pkgsMusl losing the gcc.abi setting
- pkgsCross.mingwW64.pkgsStatic losing the config string
- pkgsLLVM.pkgsMusl losing the useLLVM flag
- pkgsLLVM.pkgsStatic losing the useLLVM flag
- pkgsLLVM.pkgsi686Linux losing the useLLVM flag

And probably more.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
