### PR TITLE
postgresql.withPackages.pg_config: fix paths

### DIFF
--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -641,84 +641,71 @@ let
     f:
     let
       installedExtensions = f postgresql.pkgs;
-      finalPackage =
-        (buildEnv {
-          name = "${postgresql.pname}-and-plugins-${postgresql.version}";
-          paths = installedExtensions ++ [
-            # consider keeping in-sync with `postBuild` below
-            postgresql
-            postgresql.man # in case user installs this into environment
-          ];
+      finalPackage = buildEnv {
+        name = "${postgresql.pname}-and-plugins-${postgresql.version}";
+        paths = installedExtensions ++ [
+          postgresql
+          postgresql.man # in case user installs this into environment
+        ];
 
-          pathsToLink = [
-            "/"
-            "/bin"
-            "/share/postgresql/extension"
-            # Unbreaks Omnigres' build system
-            "/share/postgresql/timezonesets"
-            "/share/postgresql/tsearch_data"
-          ];
+        pathsToLink = [
+          "/"
+          "/bin"
+        ];
 
-          nativeBuildInputs = [ makeBinaryWrapper ];
-          postBuild =
-            let
-              args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
-            in
-            ''
-              wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
+        nativeBuildInputs = [ makeBinaryWrapper ];
+        postBuild =
+          let
+            args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
+          in
+          ''
+            wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
 
-              mkdir -p "$dev/nix-support"
-              substitute "${lib.getDev postgresql}/nix-support/pg_config.env" "$dev/nix-support/pg_config.env" \
-                --replace-fail "${postgresql}" "$out" \
-                --replace-fail "${postgresql.man}" "$out"
-            '';
+            mkdir -p "$out/nix-support"
+            substitute "${lib.getDev postgresql}/nix-support/pg_config.env" "$out/nix-support/pg_config.env" \
+              --replace-fail "${postgresql}" "$out" \
+              --replace-fail "${postgresql.man}" "$out"
+          '';
 
-          passthru = {
-            inherit installedExtensions;
-            inherit (postgresql)
-              pkgs
-              psqlSchema
-              version
+        passthru = {
+          inherit installedExtensions;
+          inherit (postgresql)
+            pkgs
+            psqlSchema
+            version
+            ;
+
+          pg_config = postgresql.pg_config.override { inherit finalPackage; };
+
+          withJIT = postgresqlWithPackages {
+            inherit
+              buildEnv
+              lib
+              makeBinaryWrapper
+              postgresql
               ;
+          } (_: installedExtensions ++ [ postgresql.jit ]);
+          withoutJIT = postgresqlWithPackages {
+            inherit
+              buildEnv
+              lib
+              makeBinaryWrapper
+              postgresql
+              ;
+          } (_: lib.remove postgresql.jit installedExtensions);
 
-            pg_config = postgresql.pg_config.override { inherit finalPackage; };
-
-            withJIT = postgresqlWithPackages {
+          withPackages =
+            f':
+            postgresqlWithPackages {
               inherit
                 buildEnv
                 lib
                 makeBinaryWrapper
                 postgresql
                 ;
-            } (_: installedExtensions ++ [ postgresql.jit ]);
-            withoutJIT = postgresqlWithPackages {
-              inherit
-                buildEnv
-                lib
-                makeBinaryWrapper
-                postgresql
-                ;
-            } (_: lib.remove postgresql.jit installedExtensions);
-
-            withPackages =
-              f':
-              postgresqlWithPackages {
-                inherit
-                  buildEnv
-                  lib
-                  makeBinaryWrapper
-                  postgresql
-                  ;
-              } (ps: installedExtensions ++ f' ps);
-          };
-        }).overrideAttrs
-          {
-            # buildEnv doesn't support passing `outputs`, so going via overrideAttrs.
-            outputs = [
-              "out"
-              "dev"
-            ];
-          };
+            } (ps: installedExtensions ++ f' ps);
+        };
+      };
     in
     finalPackage;
 


### PR DESCRIPTION
Previously, pg_config would report the paths of the underlying postgresql derivation and not the paths of the buildEnv that postgresql.withPackages creates.

That's a problem when users of pg_config use it to find PostgreSQL's sharedir, in which they'd like to find the extensions added via withPackages. Those are only linked into the created buildEnv, but not available in the postgresql derivation.

By providing our own nix-support/pg_config.env file, we can swap out those paths. We also do the same for the -man output, because this output is linked into buildEnv as well. Other paths, which are not available in the buildEnv environment, will still link to the original postgresql derivation. Win-win!

(cherry picked from commit b2e5044b3e79793df83d01c9983c054cae5ea6ff)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc